### PR TITLE
Fixed Integration required Error & Packages Error.

### DIFF
--- a/utils/PatchesParser.js
+++ b/utils/PatchesParser.js
@@ -10,9 +10,8 @@ module.exports = async function parsePatch(packageName, hasRoot) {
   );
 
   const rootedPatches = [
-    'microg-support',
-    'hide-cast-button',
-    'music-microg-support'
+    'Vanced MicroG support',
+    'Hide cast button',
   ];
   const patches = [];
 
@@ -48,7 +47,11 @@ module.exports = async function parsePatch(packageName, hasRoot) {
     if (isRooted && !hasRoot) continue;
 
     for (const dependencyName of patch.dependencies) {
-      if (dependencyName.includes('integrations')) {
+      if (
+        dependencyName.includes('integrations') ||
+        dependencyName.includes('Integrations') ||
+        dependencyName.includes('INTEGRATIONS')
+      ) {
         global.jarNames.patch.integrations = true;
       } else {
         if (!global.jarNames.patch.integrations) {

--- a/utils/mountReVancedInstaller.js
+++ b/utils/mountReVancedInstaller.js
@@ -28,6 +28,18 @@ async function runCommand(command, deviceId) {
 module.exports = async function mountReVancedInstaller(deviceId) {
   let pkg = global.jarNames.selectedApp.packageName;
 
+  // await exec(`adb install input.apk
+  //               java -jar ${global.jarNames.cli} \
+  //               -a input.apk \
+  //               -o patched-output.apk \
+  //               -b ${global.jarNames.patchesJar} \
+  //               -e vanced-microg-support \
+  //               -d ${deviceId} \
+  //               -m ${global.jarNames.integrations} \
+  //               -i remove-player-controls-background \
+  //               -i predictive-back-gesture \
+  //               --mount`);
+
   // Copy ReVanced APK to temp.
   await exec(
     `adb -s ${deviceId} push "${joinPath(
@@ -84,7 +96,6 @@ module.exports = async function mountReVancedInstaller(deviceId) {
     `su -mm -c '"/data/adb/service.d/mount_revanced_${pkg}.sh"'`,
     deviceId
   );
-
   // Restart app
   await runCommand(
     `su -c 'monkey -p ${pkg} 1 && kill $(pidof -s ${pkg})'`,

--- a/wsEvents/patchApp.js
+++ b/wsEvents/patchApp.js
@@ -156,6 +156,8 @@ module.exports = async function patchApp(ws) {
     global.jarNames.cli,
     '-b',
     global.jarNames.patchesJar,
+    '-m',
+    global.jarNames.integrations,
     '-t',
     './revanced-cache',
     '--experimental',

--- a/wsEvents/patchApp.js
+++ b/wsEvents/patchApp.js
@@ -156,8 +156,6 @@ module.exports = async function patchApp(ws) {
     global.jarNames.cli,
     '-b',
     global.jarNames.patchesJar,
-    '-m',
-    global.jarNames.integrations,
     '-t',
     './revanced-cache',
     '--experimental',


### PR DESCRIPTION
It was caused due to updated naming convention of patches. In newer update revanced-integeration.apk wasn't being imported was also due to updated naming convention.